### PR TITLE
Fix: remove invalid fallback URL to solve issues on Firefox for Android

### DIFF
--- a/src/keyshare.js
+++ b/src/keyshare.js
@@ -43,8 +43,7 @@ $.getScript("./config.js", function() {
         if (userAgent === "Android") {
             // Universal links are not stable in Android webviews and custom tabs, so always use intent links.
             let intent = `Intent;package=org.irmacard.cardemu;scheme=irma;l.timestamp=${Date.now()}`;
-            let fallback = `S.browser_fallback_url=${encodeURIComponent(universalLink)}`;
-            returnButton.attr("href", `intent://#${intent};${fallback};end`);
+            returnButton.attr("href", `intent://#${intent};end`);
         } else {
             returnButton.attr("href", universalLink);
         }


### PR DESCRIPTION
The URL to go back when opening an enrollment email also used a `intent://` link. However, this link was not even valid. The user landed on the session pointer fallback page with an error that no `sessionPtr` could be found. Then the default fallback of going to the play store is already better in my opinion.