### PR TITLE
Fix: error handling while logging out during another error

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -8,7 +8,7 @@ import ErrorMessage from './components/error_message';
 
 const mapStateToProps = state => {
   return {
-    loading: state.login.sessionState === 'unknown',
+    loading: ['unknown', 'loggingOut'].includes(state.login.sessionState),
     loggedIn: state.login.sessionState === 'loggedIn',
     registrationVerified: state.login.sessionState === 'showPostRegistration',
     errorRaised: state.login.error !== '',
@@ -17,10 +17,10 @@ const mapStateToProps = state => {
 
 // TODO: Maybe convert into router to improve URL structure.
 const App = (props) => {
-  if (props.loading) {
-    return <LoadingSpinner/>;
-  } else if (props.errorRaised) {
+  if (props.errorRaised) {
     return <ErrorMessage/>;
+  } else if (props.loading) {
+    return <LoadingSpinner/>;
   } else if (props.loggedIn) {
     return <AccountOverview/>;
   } else if (props.registrationVerified) {

--- a/src/components/account_overview/index.js
+++ b/src/components/account_overview/index.js
@@ -51,7 +51,7 @@ class AccountOverview extends React.Component {
       <>
         <IrmaAppBar
           title={this.t('title')}
-          onLogout={() => this.props.dispatch({type: 'loggedOut'})}
+          onLogout={() => this.props.dispatch({type: 'logout'})}
         />
         {this.renderBody()}
       </>

--- a/src/components/error_message/index.js
+++ b/src/components/error_message/index.js
@@ -16,7 +16,6 @@ const mapStateToProps = state => {
 const ErrorMessage = (props) => {
   const onRetry = () => {
     props.dispatch({type: 'resolveError'});
-    props.dispatch({type: 'loggedOut'});
   }
 
   return (

--- a/src/components/login/select_method.js
+++ b/src/components/login/select_method.js
@@ -28,7 +28,7 @@ class SelectMethod extends React.Component {
     })
     .catch((err) => {
       if (err !== "Aborted")
-        console.error(err); // TODO: show in error page
+        this.props.dispatch({ type: 'raiseError', errorMessage: `Error while logging in with IRMA: ${err}` });
     });
   }
 

--- a/src/store/loginstate.js
+++ b/src/store/loginstate.js
@@ -43,6 +43,11 @@ export default function login(state = initialState, action) {
                 ...state,
                 sessionState: 'loggedIn',
             };
+        case 'logout':
+            return {
+                ...state,
+                sessionState: 'loggingOut',
+            };
         case 'loggedOut':
             return {
                 ...state,
@@ -65,6 +70,7 @@ export default function login(state = initialState, action) {
         case 'resolveError':
             return {
                 ...state,
+                sessionState: 'loggingOut',
                 error: '',
             };
         default:


### PR DESCRIPTION
Because there was no loading screen while logging out, race conditions could occur when an error occurred during the logout. I fixed that my adding this loading screen, such that decisions have to be made explicit.